### PR TITLE
Add an example for non android modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,14 @@ apply plugin: "guru.stefma.artifactorypublish"
 
 version = "0.0.1"
 group = "guru.stefma.artifactorypublish"
+
+// For Java/Kotlin modules
+javaArtifact {
+    artifactId = "my-java-module"
+}
+// or for Android modules
 androidArtifact {
-    artifactId = "android"
+    artifactId = "my-android-module"
 }
 
 artifactoryPublish {


### PR DESCRIPTION
I was facing this issue:

```
* What went wrong:
Execution failed for task ':xxx:generateMetadataFileForXXXPublication'.
> Cannot query the value of this property because it has no value available.
```

and realized it's because the artifactId was not specified (I'm working with a non android project).

This PR is updating the README to indicates to both Android and non Android users how to set this value.